### PR TITLE
include product_images_attributes

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -54,6 +54,6 @@ class ProductsController < ApplicationController
     end
 
     def product_params
-      params.require(:product).permit(:name, :description, :price)
+      params.require(:product).permit(:name, :description, :price, product_images_attributes: [:image_id])
     end
 end


### PR DESCRIPTION
allow `product_images_attributes: [:image_id]`, so products_controller can access.